### PR TITLE
changed nn.Tanh() output layers to nn.Sigmoid()

### DIFF
--- a/models/beta_vae.py
+++ b/models/beta_vae.py
@@ -83,7 +83,7 @@ class BetaVAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
 
     def encode(self, input: Tensor) -> List[Tensor]:
         """

--- a/models/betatc_vae.py
+++ b/models/betatc_vae.py
@@ -79,7 +79,7 @@ class BetaTCVAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
 
     def encode(self, input: Tensor) -> List[Tensor]:
         """

--- a/models/cat_vae.py
+++ b/models/cat_vae.py
@@ -83,7 +83,7 @@ class CategoricalVAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
         self.sampling_dist = torch.distributions.OneHotCategorical(1. / categorical_dim * torch.ones((self.categorical_dim, 1)))
 
     def encode(self, input: Tensor) -> List[Tensor]:

--- a/models/cvae.py
+++ b/models/cvae.py
@@ -78,7 +78,7 @@ class ConditionalVAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
 
     def encode(self, input: Tensor) -> List[Tensor]:
         """

--- a/models/dfcvae.py
+++ b/models/dfcvae.py
@@ -76,7 +76,7 @@ class DFCVAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
 
         self.feature_network = vgg19_bn(pretrained=True)
 

--- a/models/dip_vae.py
+++ b/models/dip_vae.py
@@ -73,7 +73,7 @@ class DIPVAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
 
     def encode(self, input: Tensor) -> List[Tensor]:
         """

--- a/models/fvae.py
+++ b/models/fvae.py
@@ -73,7 +73,7 @@ class FactorVAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
 
         # Discriminator network for the Total Correlation (TC) loss
         self.discriminator = nn.Sequential(nn.Linear(self.latent_dim, 1000),

--- a/models/hvae.py
+++ b/models/hvae.py
@@ -101,7 +101,7 @@ class HVAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
 
         # ========================================================================#
         # Pesudo Input for the Vamp-Prior

--- a/models/info_vae.py
+++ b/models/info_vae.py
@@ -83,7 +83,7 @@ class InfoVAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
 
     def encode(self, input: Tensor) -> List[Tensor]:
         """

--- a/models/iwae.py
+++ b/models/iwae.py
@@ -73,7 +73,7 @@ class IWAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
 
     def encode(self, input: Tensor) -> List[Tensor]:
         """

--- a/models/joint_vae.py
+++ b/models/joint_vae.py
@@ -105,7 +105,7 @@ class JointVAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
         self.sampling_dist = torch.distributions.OneHotCategorical(1. / categorical_dim * torch.ones((self.categorical_dim, 1)))
 
     def encode(self, input: Tensor) -> List[Tensor]:

--- a/models/logcosh_vae.py
+++ b/models/logcosh_vae.py
@@ -73,7 +73,7 @@ class LogCoshVAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
 
     def encode(self, input: Tensor) -> List[Tensor]:
         """

--- a/models/lvae.py
+++ b/models/lvae.py
@@ -128,7 +128,7 @@ class LVAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
         hidden_dims.reverse()
 
     def encode(self, input: Tensor) -> List[Tensor]:

--- a/models/miwae.py
+++ b/models/miwae.py
@@ -76,7 +76,7 @@ class MIWAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
 
     def encode(self, input: Tensor) -> List[Tensor]:
         """

--- a/models/mssim_vae.py
+++ b/models/mssim_vae.py
@@ -75,7 +75,7 @@ class MSSIMVAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
 
         self.mssim_loss = MSSIM(self.in_channels,
                                 window_size,

--- a/models/swae.py
+++ b/models/swae.py
@@ -79,7 +79,7 @@ class SWAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
 
     def encode(self, input: Tensor) -> Tensor:
         """

--- a/models/twostage_vae.py
+++ b/models/twostage_vae.py
@@ -70,7 +70,7 @@ class TwoStageVAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
 
         #---------------------- Second VAE ---------------------------#
         encoder2 = []

--- a/models/vampvae.py
+++ b/models/vampvae.py
@@ -73,11 +73,11 @@ class VampVAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
 
         self.pseudo_input = torch.eye(self.num_components, requires_grad= False)
         self.embed_pseudo = nn.Sequential(nn.Linear(self.num_components, 12288),
-                                          nn.Hardtanh(0.0, 1.0)) # 3x64x64 = 12288
+                                          nn.HardSigmoid(0.0, 1.0)) # 3x64x64 = 12288
 
     def encode(self, input: Tensor) -> List[Tensor]:
         """

--- a/models/vanilla_vae.py
+++ b/models/vanilla_vae.py
@@ -72,7 +72,7 @@ class VanillaVAE(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
 
     def encode(self, input: Tensor) -> List[Tensor]:
         """

--- a/models/vq_vae.py
+++ b/models/vq_vae.py
@@ -161,7 +161,7 @@ class VQVAE(BaseVAE):
                                    out_channels=3,
                                    kernel_size=4,
                                    stride=2, padding=1),
-                nn.Tanh()))
+                nn.Sigmoid()))
 
         self.decoder = nn.Sequential(*modules)
 

--- a/models/wae_mmd.py
+++ b/models/wae_mmd.py
@@ -76,7 +76,7 @@ class WAE_MMD(BaseVAE):
                             nn.LeakyReLU(),
                             nn.Conv2d(hidden_dims[-1], out_channels= 3,
                                       kernel_size= 3, padding= 1),
-                            nn.Tanh())
+                            nn.Sigmoid())
 
     def encode(self, input: Tensor) -> Tensor:
         """


### PR DESCRIPTION
The input image is normalized between 0-1, so the output should be a nn.Sigmoid() layer instead of nn.Tanh(). Note that nn.Tanh() may also work, but using nn.Sigmoid() is more appropriate and will make the learning easier since the network can now only output values between 0-1 every pixel. 